### PR TITLE
Update .markdownlint.json

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -14,7 +14,6 @@
 	"MD044": {
 		"code_blocks": false,
 		"names": [
-			"OpenMetal",
 			"OpenStack",
 			"Kolla Ansible",
 			"kolla-ansible",


### PR DESCRIPTION
remove openmetal from list to resolve lint issues where openmetal is contained in URL names