### PR TITLE
Update openstackclient.md

### DIFF
--- a/docs/operators-manual/day-1/command-line/openstackclient.md
+++ b/docs/operators-manual/day-1/command-line/openstackclient.md
@@ -146,9 +146,13 @@ For example:
 For an initial command, list the servers associated with your project by
 running `openstack server list`.
 
+If your cloud is configured with a Self Signed certificate (our default)
+you will need to pass the `--insecure` flag with your commands, otherwise
+you will get a SSL Verify error due to the self signed certficiate.
+
 For example:
 
-    $ openstack server list
+    $ openstack --insecure server list
     +--------------------------------------+-------------+--------+----------------------------------------+--------------------------+----------+
     | ID                                   | Name        | Status | Networks                               | Image                    | Flavor   |
     +--------------------------------------+-------------+--------+----------------------------------------+--------------------------+----------+


### PR DESCRIPTION
Numerous times users complain that they get a TLS SSL VERIFY error when following this guide. This block explains our default configuration.