### PR TITLE
Add instanceId to chat widget init settings

### DIFF
--- a/src/modules/chatWidget.ts
+++ b/src/modules/chatWidget.ts
@@ -13,6 +13,7 @@ const isCrawl = typeof navigator !== 'undefined' && /bot|crawler|spider|crawling
 const chatWidgetConfig = {
   scriptUrl: 'https://chat.openmetal.app/widget/widget.js',
   settings: {
+    instanceId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
     theme: {
       primaryColor: '#22C4A1',
       position: 'bottom-right'


### PR DESCRIPTION
## Summary
- Adds `instanceId: 'f47ac10b-58cc-4372-a567-0e02b2c3d479'` to the settings object passed to `window.ChatWidget.init()` in `src/modules/chatWidget.ts`.

## Test plan
- [ ] Run `npm start` and confirm the chat widget still loads without errors in the browser console
- [ ] Verify the widget initializes with the new `instanceId` on the hosted widget side

🤖 Generated with [Claude Code](https://claude.com/claude-code)