### PR TITLE
Add Algolia DocSearch with Ask AI

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -146,6 +146,15 @@ const config = {
         hideOnScroll: false,
         items: [],
       },
+      algolia: {
+        appId: 'OZG8Q0XSE2',
+        apiKey: '60665066de52b25fdb493cb75b802db2',
+        indexName: 'docusaurusOpenMetal Docs Docusarus',
+        askAi: {
+          assistantId: '2bc66529-5f34-44bd-b9d0-7541e5bb4d98',
+          agentStudio: true,
+        },
+      },
     }),
   customFields: {
     navbarTopRow: [

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   },
   "dependencies": {
     "@algolia/client-search": ">= 4.9.1 < 6",
+    "@docsearch/css": "4.6.2",
+    "@docsearch/js": "4.6.2",
     "@docusaurus/core": "^2.2.0",
     "@docusaurus/cssnano-preset": "2.2.0",
     "@docusaurus/plugin-client-redirects": "2.2.0",

--- a/src/components/Navbar/index.js
+++ b/src/components/Navbar/index.js
@@ -250,6 +250,7 @@ function NavbarCustom() {
             titleClassName="navbar__title"
           />
           <div className="linkContainer">
+            {!hasSearchNavbarItem && <SearchBar />}
             {useDocusaurusContext().siteConfig.customFields.navbarTopRow.map((item, i) => (
               <NavbarItem {...item} key={i} target="_self" />
             ))}
@@ -285,7 +286,6 @@ function NavbarCustom() {
               onChange={colorModeToggle.toggle}
             />
           )}
-          {!hasSearchNavbarItem && <SearchBar />}
         </div>
       </div>
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -87,6 +87,10 @@ h6 {
 	flex-direction: column;
 	align-items: center;
 }
+
+.DocSearch-Container {
+	z-index: 10000000 !important;
+}
 .omi-navbar .navbar__brand {
 	margin-right: 5rem;
 }
@@ -176,6 +180,9 @@ h6 {
 	display: flex;
 	justify-content: flex-end;
 	flex-direction: row;
+}
+.omi-navbar .navbar_top_row .linkContainer .DocSearch-Button {
+	margin-top: 5px;
 }
 .omi-navbar .navbar_top_row .navbar__link {
 	display: block;

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -1,0 +1,66 @@
+/**
+ * Swizzled SearchBar.
+ *
+ * Why this exists: @docusaurus/theme-search-algolia@2.2.0 bundles
+ * @docsearch/react@3.3.1, which does not support Ask AI. Ask AI is a
+ * DocSearch v4 feature. The official @docsearch/docusaurus-adapter requires
+ * React 18+, and this site is pinned to React 17 via Docusaurus 2.2.0.
+ *
+ * Workaround: use the zero-dependency @docsearch/js@4 vanilla package and
+ * mount it into a container in place of the default SearchBar.
+ */
+import React, {useEffect, useRef} from 'react';
+import docsearch from '@docsearch/js';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import {useHistory} from '@docusaurus/router';
+import {useBaseUrlUtils} from '@docusaurus/useBaseUrl';
+import '@docsearch/css';
+
+export default function SearchBar() {
+  const {siteConfig} = useDocusaurusContext();
+  const config = siteConfig.themeConfig.algolia;
+  const history = useHistory();
+  const {withBaseUrl} = useBaseUrlUtils();
+  const containerRef = useRef(null);
+  const mountedRef = useRef(false);
+
+  useEffect(() => {
+    if (mountedRef.current || !containerRef.current) return;
+    mountedRef.current = true;
+
+    docsearch({
+      container: containerRef.current,
+      appId: config.appId,
+      apiKey: config.apiKey,
+      indexName: config.indexName,
+      ...(config.askAi ? {askAi: config.askAi} : {}),
+      searchParameters: {
+        facetFilters: [['version:current']],
+      },
+      navigator: {
+        navigate({itemUrl}) {
+          try {
+            const u = new URL(itemUrl, window.location.origin);
+            if (u.origin === window.location.origin) {
+              history.push(`${u.pathname}${u.hash}`);
+              return;
+            }
+          } catch (_) {}
+          window.location.href = itemUrl;
+        },
+      },
+      transformItems(items) {
+        return items.map((item) => {
+          try {
+            const u = new URL(item.url);
+            return {...item, url: withBaseUrl(`${u.pathname}${u.hash}`)};
+          } catch (_) {
+            return item;
+          }
+        });
+      },
+    });
+  }, []);
+
+  return <div ref={containerRef} />;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1205,6 +1205,16 @@
   resolved "https://registry.npmjs.org/@docsearch/css/-/css-3.3.1.tgz"
   integrity sha512-nznHXeFHpAYjyaSNFNFpU+IJPjQA7AINM8ONjDx/Zx4O/pGAvqwgmcLNc7zR8qXRutqnzLo06yN63xFn36KFBw==
 
+"@docsearch/css@4.6.2":
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/@docsearch/css/-/css-4.6.2.tgz#986776619dccbf798176c75e858cc22f5e710bb4"
+  integrity sha512-fH/cn8BjEEdM2nJdjNMHIvOVYupG6AIDtFVDgIZrNzdCSj4KXr9kd+hsehqsNGYjpUjObeKYKvgy/IwCb1jZYQ==
+
+"@docsearch/js@4.6.2":
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/@docsearch/js/-/js-4.6.2.tgz#5ead6074c081f7eec72bffba6b7ab9ab13e1f2c9"
+  integrity sha512-qj1yoxl3y4GKoK7+VM6fq/rQqPnvUmg3IKzJ9x0VzN14QVzdB/SG/J6VfV1BWT5RcPUFxIcVwoY1fwHM2fSRRw==
+
 "@docsearch/react@^3.1.1":
   version "3.3.1"
   resolved "https://registry.npmjs.org/@docsearch/react/-/react-3.3.1.tgz"
@@ -1485,7 +1495,7 @@
     "@docusaurus/theme-search-algolia" "2.2.0"
     "@docusaurus/types" "2.2.0"
 
-"@docusaurus/react-loadable@5.5.2", "react-loadable@npm:@docusaurus/react-loadable@5.5.2":
+"@docusaurus/react-loadable@5.5.2":
   version "5.5.2"
   resolved "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz"
   integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
@@ -7168,7 +7178,7 @@ opener@^1.5.2:
     disqus-react "^1.1.5"
     live-server "^1.2.2"
     markdownlint-cli "^0.31.1"
-    openmetal-docs "file:../../../.cache/yarn/v6/npm-openmetal-docs-0.0.0-9a61ce88-d07c-493d-b15c-ca35ef711358-1756133770410/node_modules/openmetal-docs"
+    openmetal-docs "file:../../.cache/yarn/v6/npm-openmetal-docs-0.0.0-a57fe10f-7b5b-4f9b-bb9e-1f77e5f8a6e2-1776971802181/node_modules/openmetal-docs"
     prism-react-renderer "^1.2.1"
     react "^17.0.1"
     react-dom "^17.0.1"
@@ -8092,6 +8102,14 @@ react-loadable@*:
   integrity sha512-C8Aui0ZpMd4KokxRdVAm2bQtI03k2RMRNzOB+IipV3yxFTSVICv7WoUr5L9ALB5BmKO1iHgZtWM8EvYG83otdg==
   dependencies:
     prop-types "^15.5.0"
+
+"react-loadable@npm:@docusaurus/react-loadable@5.5.2":
+  version "5.5.2"
+  resolved "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz"
+  integrity sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==
+  dependencies:
+    "@types/react" "*"
+    prop-types "^15.6.2"
 
 react-router-config@^5.1.1:
   version "5.1.1"


### PR DESCRIPTION
## Summary
- Adds Algolia DocSearch v4 + Ask AI to the docs site
- Search bar lives in the top navbar row, left of CONTACT/TRIAL/LOGIN
- Results filtered to current-version content via Algolia facet filters

## Why vanilla `@docsearch/js` instead of `themeConfig.algolia`
The bundled `@docusaurus/theme-search-algolia@2.2.0` ships `@docsearch/react@3.3.1`, which predates Ask AI (v4 feature). Algolia's recommended workaround (`@docsearch/docusaurus-adapter`) requires React 18+, but this site is pinned to React 17 via Docusaurus 2.2.0. The zero-dependency `@docsearch/js@4` bypasses both constraints.

The swizzled `src/theme/SearchBar/index.js` mounts vanilla `docsearch()` into the SearchBar slot, reads config from `themeConfig.algolia`, and passes `askAi` through. Tradeoff: no per-docs-instance contextual scoping (Docusaurus's `useAlgoliaContextualFacetFilters` hook doesn't apply when bypassing the React theme), but `version:current` facet filter is applied statically to cover the "only v3 results" requirement.

## Other fixes in this PR
- Navbar SearchBar rendering moved from `.navbar__items--right` into `.navbar_top_row .linkContainer` (so it's in the top row next to CONTACT)
- `.DocSearch-Container` z-index bumped above the navbar's `9999999` so the modal isn't hidden behind the navbar
- 5px top margin on the search button for vertical alignment with adjacent nav links

## Test plan
- [ ] `yarn start` and load `http://localhost:3000/docs/manuals/`
- [ ] Click Search (top right, to the left of CONTACT) — modal opens on top of the navbar
- [ ] Query "kubernetes" or "ceph" — results appear, grouped by section, current-version only
- [ ] Click the "Ask AI: \<query\>" banner — assistant panel opens
- [ ] Confirm no \`operators_versioned_docs/version-1.0\` or \`version-2.0\` URLs leak into results

🤖 Generated with [Claude Code](https://claude.com/claude-code)