### PR TITLE
update kolla build history

### DIFF
--- a/docs/kolla-image-update/build-history.md
+++ b/docs/kolla-image-update/build-history.md
@@ -43,6 +43,7 @@ index.
 
 | Tag | Build Date | Services | Notes |
 |---|---|---|---|
+| 2023.2-ubuntu-jammy-2026-06-18 | 06/18/2026 | Nova |[[OSSA-2026-022] Nova scheduler hint injection bypasses Placement resource claims and scheduling constraints](https://security.openstack.org/ossa/OSSA-2026-022.html)|
 | 2023.2-ubuntu-jammy-2026-05-29 | 05/29/2026 | Keystone |[[OSSA-2026-015] Keystone credential delegation project boundary enforcement patched](https://security.openstack.org/ossa/OSSA-2026-015.html)|
 | 2023.2-ubuntu-jammy-2026-03-24 | 03/24/2026 | Glance |[[OSSA-2026-004] Server-Side Request Forgery (SSRF) vulnerabilities in OpenStack Glance image import functionality patched](https://bugs.launchpad.net/glance/+bug/2138602)|
 ||| Mistral |[Cron trigger/event trigger bug patched](https://review.opendev.org/c/openstack/mistral/+/905206)|
@@ -70,6 +71,7 @@ Latest image tag: `yoga`
 
 | Tag | Build Date | Services | Notes |
 |---|---|---|---|
+| yoga-2026-06-18 | 06/18/2026 | Nova |[[OSSA-2026-022] Nova scheduler hint injection bypasses Placement resource claims and scheduling constraints](https://security.openstack.org/ossa/OSSA-2026-022.html)|
 | yoga-2026-05-29 | 05/29/2026 | Keystone |[[OSSA-2026-015] Keystone credential delegation project boundary enforcement patched](https://security.openstack.org/ossa/OSSA-2026-015.html)|
 | yoga-2026-03-24 | 03/24/2026 | Glance |[[OSSA-2026-004] Server-Side Request Forgery (SSRF) vulnerabilities in OpenStack Glance image import functionality patched](https://bugs.launchpad.net/glance/+bug/2138602)|
 ||| Nova |[[OSSA-2026-002] Nova calls qemu-img without format restrictions for resize (CVE-2026-24708) patched](https://bugs.launchpad.net/nova/+bug/2137507)|


### PR DESCRIPTION
Added https://security.openstack.org/ossa/OSSA-2026-022.html to kolla image build history page